### PR TITLE
feat: 施設別テンプレート一括複製機能のドキュメント追加

### DIFF
--- a/projects/medical-supplies-appsheet/README.md
+++ b/projects/medical-supplies-appsheet/README.md
@@ -7,19 +7,13 @@
 ```
 medical-supplies-appsheet/
 ├── appsheet/                   # AppSheet関連ファイル
-│   ├── app-definition.json     # AppSheetアプリ定義
+│   ├── implementation-guides/  # 実装ガイド
+│   │   └── 06-facility-templates-bulk-copy.md  # 施設別テンプレート一括複製
 │   ├── table-schemas/          # テーブルスキーマ定義
 │   │   ├── supplies.json       # 医材マスタ
-│   │   ├── inventory.json      # 在庫管理
-│   │   ├── orders.json         # 発注記録
-│   │   └── usage-logs.json     # 使用履歴
-│   ├── workflows/              # ワークフロー定義
-│   │   ├── order-approval.json # 発注承認フロー
-│   │   └── stock-alert.json    # 在庫アラート
-│   └── views/                  # ビュー定義
-│       ├── dashboard.json      # ダッシュボード
-│       ├── inventory-list.json # 在庫一覧
-│       └── order-form.json     # 発注フォーム
+│   │   └── inventory.json      # 在庫管理
+│   ├── workflows/              # ワークフロー定義（現在空）
+│   └── views/                  # ビュー定義（現在空）
 ├── gas-integration/            # GAS連携スクリプト
 │   ├── src/
 │   │   ├── csvExporter.ts      # CSV一括出力機能
@@ -30,13 +24,22 @@ medical-supplies-appsheet/
 │   └── .clasp.json
 ├── documents/                  # プロジェクトドキュメント
 │   ├── requirements.md         # 要件定義
-│   ├── data-model.md          # データモデル設計
-│   ├── user-manual.md         # ユーザーマニュアル
-│   └── deployment.md          # デプロイ手順
-├── scripts/                    # 運用スクリプト
-│   ├── setup.sh               # 初期セットアップ
-│   ├── backup.sh              # バックアップ
-│   └── deploy.sh              # デプロイ
+│   └── data-model.md          # データモデル設計
+├── scripts/                    # 運用スクリプト（現在空）
+├── data-model/                 # データモデル
+│   ├── csv-data/              # CSVデータファイル
+│   │   ├── masters/           # マスタデータ
+│   │   │   ├── 施設マスタ.csv
+│   │   │   ├── 患者マスタ.csv
+│   │   │   ├── 商品マスタ.csv
+│   │   │   ├── 配布テンプレート.csv
+│   │   │   └── その他マスタファイル
+│   │   └── transactions/      # トランザクションデータ
+│   │       ├── 配布記録.csv
+│   │       ├── 在庫変動履歴.csv
+│   │       └── その他取引ファイル
+│   ├── documentation/         # データモデルドキュメント
+│   └── README.md              # データモデル説明
 └── README.md                   # このファイル
 ```
 
@@ -68,15 +71,20 @@ medical-supplies-appsheet/
 - カスタムシート選択出力
 - データバックアップとリポジトリ取り込み対応
 
+### 6. 施設別テンプレート一括複製機能
+- 施設選択による関連テンプレート表示
+- 複数テンプレートの一括選択
+- 配布記録への一括複製
+- 奇数月/偶数月の自動数量判定
+- 患者別・施設別の配布タイプ自動判定
+
 ## セットアップ手順
 
 1. AppSheetでの新規アプリ作成
 2. テーブルスキーマの設定
-3. ワークフローの設定
+3. ワークフローの設定（必要に応じて）
 4. ビューのカスタマイズ
-5. GAS連携の設定（必要に応じて）
-
-詳細は `documents/deployment.md` を参照してください。
+5. GAS連携の設定（CSV出力機能使用時）
 
 ## CSV一括出力機能
 
@@ -172,6 +180,42 @@ exportCustomSheetsButton()
 - AppSheetの設定変更は必ずJSONファイルに反映すること
 - データモデルの変更時は `documents/data-model.md` を更新すること
 - 新機能追加時は要件定義を更新すること
+
+## 施設別テンプレート一括複製機能
+
+### 機能概要
+
+配布テンプレートから施設単位で複数のテンプレートを選択し、配布記録に一括複製する機能です。定期配布の効率化と、施設ごとの一括処理を実現します。
+
+### 主な機能
+
+1. **施設選択ビュー**
+   - 施設一覧から複製元の施設を選択
+   - 施設ごとのテンプレート数を表示
+
+2. **テンプレート選択機能**
+   - 選択した施設のテンプレート一覧表示
+   - チェックボックスによる複数選択
+   - 全選択/選択解除ボタン
+
+3. **一括複製処理**
+   - 選択したテンプレートを配布記録に複製
+   - 配布IDの自動生成（重複しないタイムスタンプ形式）
+   - 奇数月/偶数月に応じた数量の自動設定
+   - 個別配布/施設配布の自動判定
+
+### 実装詳細
+
+詳しい実装手順は `appsheet/implementation-guides/06-facility-templates-bulk-copy.md` を参照してください。
+
+### 使用方法
+
+1. 配布テンプレート一覧ビューから施設を選択
+2. 施設別テンプレート一覧ビューに遷移
+3. 複製したいテンプレートにチェック
+4. 「選択済みを複製実行」ボタンをクリック
+5. 確認ダイアログで「OK」を選択
+6. 配布記録に自動追加される
 
 ## 関連プロジェクト
 

--- a/projects/medical-supplies-appsheet/appsheet/implementation-guides/06-facility-templates-bulk-copy.md
+++ b/projects/medical-supplies-appsheet/appsheet/implementation-guides/06-facility-templates-bulk-copy.md
@@ -1,0 +1,289 @@
+# 施設テンプレート一括複製機能 実装ガイド
+
+## 概要
+施設を選択して、その施設に関連する全ての配布テンプレートを配布記録に一括で複製する機能の実装方法。
+
+## 実装方法
+
+### 1. 配布テンプレートテーブルに選択用カラムを追加
+
+**テーブル: 配布テンプレート**
+- カラム名: `選択フラグ`
+- Type: Yes/No
+- Initial value: FALSE
+- Show: TRUE（施設別ビューでのみ表示）
+
+### 2. 施設選択用のスライスを作成
+
+**スライス名**: `施設別テンプレート`
+- Source table: 配布テンプレート
+- Row filter condition:
+```
+AND(
+  [施設ID] = CONTEXT("SelectedFacility"),
+  [有効] = TRUE
+)
+```
+
+### 3. 施設選択ビューの作成
+
+**ビュー名**: `施設選択`
+- Type: Deck または Gallery
+- For this data: 施設マスタ
+- View Options:
+  - Group by: なし
+  - Sort by: 施設名
+
+**表示設定**:
+- Primary header: [施設名]
+- Secondary header:
+```
+CONCATENATE(
+  "テンプレート数: ",
+  COUNT(SELECT(配布テンプレート[テンプレートID],
+    [施設ID] = [_THISROW].[施設ID]))
+)
+```
+
+### 4. 施設別テンプレート一覧ビューの作成
+
+**ビュー名**: `施設別テンプレート一覧`
+- Type: Table
+- For this data: 施設別テンプレート（スライス）
+- Allow QuickEdit: TRUE
+
+**カラム設定**:
+- 選択フラグ: QuickEdit有効
+- テンプレートID: 表示のみ
+- 患者ID: 表示のみ
+- 商品ID: 表示のみ
+- 奇数月数量: 表示
+- 偶数月数量: 表示
+- 配布頻度_日: 表示
+
+**グループ化**:
+- Group by: 患者ID
+- Group aggregate: なし
+
+### 5. メインアクション：施設選択から複製まで
+
+#### 5.1 施設選択アクション
+**Action name**: `施設を選択して複製`
+- For a record of this table: 施設マスタ
+- Do this: App: go to another view within this app
+- Target:
+```
+LINKTOROW([施設ID], "施設別テンプレート一覧")
+```
+- Prominence: Display prominently
+- Icon: copy_all
+
+#### 5.2 全選択/選択解除アクション
+
+**全選択アクション**
+- Action name: `全テンプレート選択`
+- For a record of this table: 配布テンプレート
+- Do this: Data: execute an action on a set of rows
+- Referenced Table: 配布テンプレート
+- Referenced Rows:
+```
+SELECT(配布テンプレート[テンプレートID],
+  [施設ID] = CONTEXT("SelectedFacility"))
+```
+- Referenced Action: `選択フラグON`（個別アクション）
+
+**個別選択アクション**
+- Action name: `選択フラグON`
+- For a record of this table: 配布テンプレート
+- Do this: Data: set the values of some columns in this row
+- Set these columns:
+  - 選択フラグ = TRUE
+
+#### 5.3 配布記録への複製アクション
+
+**複製実行アクション**
+- Action name: `選択テンプレートを配布記録に複製`
+- For a record of this table: 配布テンプレート
+- Do this: Data: add a new row to another table using values from this row
+- Table to add to: 配布記録
+- Set these columns:
+```
+配布ID = CONCATENATE(
+  "DIST-",
+  TEXT(NOW(), "YYYYMMDDHHmmss"),
+  RIGHT(CONCATENATE("00", RANDBETWEEN(1, 99)), 2)
+)
+
+配布日 = TODAY()
+
+施設ID = [施設ID]
+
+患者ID = [患者ID]
+
+商品ID = [商品ID]
+
+配布数量_箱 = IF(
+  OR([奇数月数量] >= 10, [偶数月数量] >= 10),
+  FLOOR(MAX([奇数月数量], [偶数月数量]) / 10),
+  0
+)
+
+配布数量_個 = IF(
+  MOD(MONTH(TODAY()), 2) = 1,
+  [奇数月数量],
+  [偶数月数量]
+)
+
+配布タイプ = IF(
+  ISNOTBLANK([患者ID]),
+  "個別配布",
+  "施設配布"
+)
+
+状態 = "準備中"
+
+配布者 = USEREMAIL()
+
+備考 = CONCATENATE(
+  TEXT(TODAY(), "YYYY/MM"),
+  " 定期配布（テンプレート一括複製）"
+)
+```
+
+**バッチ複製アクション（グループ）**
+- Action name: `選択済みテンプレート一括複製`
+- For a record of this table: 配布テンプレート
+- Do this: Grouped: execute a sequence of actions
+- Actions:
+  1. Data: execute an action on a set of rows
+     - Referenced Rows:
+     ```
+     SELECT(配布テンプレート[テンプレートID],
+       AND(
+         [施設ID] = CONTEXT("SelectedFacility"),
+         [選択フラグ] = TRUE
+       ))
+     ```
+     - Referenced Action: `選択テンプレートを配布記録に複製`
+
+  2. 選択フラグリセット（全てFALSEに）
+
+  3. 完了通知表示
+
+### 6. ボタン配置とUI
+
+#### 施設選択ビューのアクション配置
+- `施設を選択して複製`ボタンを各施設カードに表示
+
+#### 施設別テンプレート一覧ビューのアクション配置
+
+**ヘッダーアクション**:
+1. `全選択`ボタン
+2. `選択解除`ボタン
+3. `選択済みを複製実行`ボタン（確認ダイアログ付き）
+4. `施設選択に戻る`ボタン
+
+### 7. 確認ダイアログの実装
+
+**複製前の確認**
+- Condition for confirmation:
+```
+COUNT(SELECT(配布テンプレート[テンプレートID],
+  AND(
+    [施設ID] = CONTEXT("SelectedFacility"),
+    [選択フラグ] = TRUE
+  ))) > 0
+```
+
+- Confirmation message:
+```
+CONCATENATE(
+  "選択された ",
+  COUNT(SELECT(配布テンプレート[テンプレートID],
+    AND(
+      [施設ID] = CONTEXT("SelectedFacility"),
+      [選択フラグ] = TRUE
+    ))),
+  " 件のテンプレートを配布記録に複製します。",
+  CHAR(10),
+  "よろしいですか？"
+)
+```
+
+### 8. 重複チェックと検証
+
+**Valid If（配布記録テーブル）**:
+```
+NOT(IN(
+  CONCATENATE([配布日], [施設ID], [患者ID], [商品ID]),
+  SELECT(
+    配布記録[CONCATENATE([配布日], [施設ID], [患者ID], [商品ID])],
+    [配布ID] <> [_THISROW].[配布ID]
+  )
+))
+```
+
+**Error message**:
+```
+"同じ日付・施設・患者・商品の組み合わせが既に存在します"
+```
+
+### 9. 完了後の処理
+
+**複製完了後のアクション**:
+1. 選択フラグを全てFALSEにリセット
+2. 成功メッセージを表示
+3. 配布記録一覧ビューに遷移（フィルタ付き）
+
+**遷移先のフィルタ**:
+```
+AND(
+  [配布日] = TODAY(),
+  [配布者] = USEREMAIL(),
+  CONTAINS([備考], "テンプレート一括複製")
+)
+```
+
+### 10. 権限制御
+
+**アクション表示条件**:
+```
+AND(
+  USERSETTINGS("権限") IN LIST("管理者", "看護師"),
+  OR(
+    USERSETTINGS("権限") = "管理者",
+    [施設ID] IN USERSETTINGS("担当施設")
+  )
+)
+```
+
+## 実装手順
+
+1. **Step 1**: 配布テンプレートテーブルに`選択フラグ`カラムを追加
+2. **Step 2**: 施設別テンプレートスライスを作成
+3. **Step 3**: 施設選択ビューを作成
+4. **Step 4**: 施設別テンプレート一覧ビューを作成
+5. **Step 5**: 個別アクション（選択、複製）を作成
+6. **Step 6**: グループアクション（一括処理）を作成
+7. **Step 7**: ビューにアクションボタンを配置
+8. **Step 8**: 確認ダイアログと検証ルールを設定
+9. **Step 9**: 権限制御を実装
+10. **Step 10**: テスト実行と調整
+
+## 注意事項
+
+- 大量のテンプレートを一度に複製する場合、パフォーマンスに影響する可能性があります
+- 配布IDの一意性を保証するため、タイムスタンプとランダム値を組み合わせています
+- 月の奇数・偶数に応じて配布数量を自動判定します
+- 患者IDがない場合は「施設配布」として扱います
+
+## テスト項目
+
+- [ ] 施設選択が正しく動作するか
+- [ ] テンプレートの選択/選択解除が正しく動作するか
+- [ ] 選択したテンプレートのみが複製されるか
+- [ ] 配布記録のIDが重複しないか
+- [ ] 奇数月/偶数月の数量判定が正しいか
+- [ ] 権限に応じたアクション表示制御が機能するか
+- [ ] 複製後の選択フラグリセットが動作するか
+- [ ] 完了後のビュー遷移とフィルタが正しく動作するか


### PR DESCRIPTION
## Summary
- 医療材料在庫管理システムに施設別テンプレート一括複製機能を追加
- AppSheet実装ガイドとして詳細な手順書を作成
- プロジェクトREADMEを更新し、新機能の説明を追加

## Changes
- `projects/medical-supplies-appsheet/README.md`: プロジェクト構造と新機能の説明を更新
- `projects/medical-supplies-appsheet/appsheet/implementation-guides/06-facility-templates-bulk-copy.md`: 詳細な実装ガイドを新規追加

## Test plan
- [ ] 実装ガイドの手順が明確で実行可能
- [ ] READMEの内容が最新の状態を反映
- [ ] ドキュメント間の整合性が保たれている

🤖 Generated with [Claude Code](https://claude.ai/code)