### PR TITLE
feat: 歯科カレンダー同期とPDF印刷設定を改善

### DIFF
--- a/projects/calendar-gas/src/config.ts
+++ b/projects/calendar-gas/src/config.ts
@@ -16,7 +16,7 @@ const CONFIG = {
     FOLDER_ID: '1FvHFGRSGEj29i60Wj315DZv0W2BmhPV0',
     
     // PDFエクスポート範囲
-    EXPORT_RANGE: 'C1:P25',
+    EXPORT_RANGE: 'C1:R37',
     
     // PDFの設定
     ORIENTATION: 'landscape' as const, // 横向き
@@ -53,11 +53,27 @@ const CONFIG = {
     // カレンダーID（'primary'はデフォルトカレンダー）
     // 複数のカレンダーを使用する場合は配列で指定
     CALENDAR_IDS: ['c_c89f5fd72defb5ef85547e43d4c019687042f5882de1ec7fdfd2edbb6e2064b4@group.calendar.google.com'],
-    
+
     // カレンダーデータを出力するシート名
     OUTPUT_SHEET: 'カレンダーデータ',
-    
+
     // 日付を取得するシートと範囲
+    DATE_SOURCE: {
+      SHEET_NAME: '使い方',
+      START_DATE_CELL: 'B2',  // 開始日のセル
+      END_DATE_CELL: 'B3'      // 終了日のセル
+    }
+  },
+
+  // 歯科カレンダーの設定
+  DENTAL_CALENDAR: {
+    // 歯科用カレンダーID
+    CALENDAR_ID: 'c_4b2c180413cb0c727836433b8f62d492af5d7f282a61d411c0cf3e713bb3f937@group.calendar.google.com',
+
+    // 歯科カレンダーデータを出力するシート名
+    OUTPUT_SHEET: '歯科カレンダーデータ',
+
+    // 日付を取得するシートと範囲（通常のカレンダーと同じ設定を使用）
     DATE_SOURCE: {
       SHEET_NAME: '使い方',
       START_DATE_CELL: 'B2',  // 開始日のセル

--- a/projects/calendar-gas/src/main.ts
+++ b/projects/calendar-gas/src/main.ts
@@ -58,12 +58,13 @@ function createAllPdfsButton(): any {
 
 /**
  * カレンダーデータ同期（ボタン用）
+ * 通常カレンダーと歯科カレンダーの両方を同期
  */
 function syncCalendarButton(): any {
   try {
     console.log('カレンダーデータの同期を開始します...');
     const result = syncCalendarData();
-    console.log(`同期完了: ${result.eventCount}件のイベントを取得`);
+    console.log(`同期完了: 通常カレンダー ${result.eventCount}件、歯科カレンダー ${result.dentalEventCount}件`);
     return result;
   } catch (error: any) {
     console.error(`カレンダー同期エラー: ${error.message}`);

--- a/projects/calendar-gas/src/pdfExporter.ts
+++ b/projects/calendar-gas/src/pdfExporter.ts
@@ -50,11 +50,12 @@ function createSinglePdf(facilityName: string): GoogleAppsScript.Drive.File {
   const spreadsheetId = ss.getId();
   const sheetId = calendarSheet.getSheetId();
   
+  // scale: 1=標準(100%), 2=幅に合わせる, 3=高さに合わせる, 4=ページに合わせる
   const url = `https://docs.google.com/spreadsheets/d/${spreadsheetId}/export?` +
     `format=pdf&` +
     `size=${CONFIG.PDF.SIZE === 'A4' ? '1' : '0'}&` + // 1=A4, 0=Letter
     `portrait=${CONFIG.PDF.ORIENTATION === 'landscape' ? 'false' : 'true'}&` +
-    `fitw=${CONFIG.PDF.SCALE === 'fit' ? 'true' : 'false'}&` +
+    `scale=3&` + // 高さに合わせる
     `sheetnames=false&` +
     `printtitle=false&` +
     `pagenumbers=false&` +


### PR DESCRIPTION
## Summary
- 歯科カレンダーの同期機能を追加（歯科カレンダーデータシートに出力）
- syncCalendarDataで通常カレンダーと歯科カレンダーを同時に同期
- PDF印刷設定を「高さに合わせる」(scale=3)に変更
- PDF印刷範囲をC1:R37に拡大

## Test plan
- [ ] syncCalendarButtonを実行して両カレンダーが同期されることを確認
- [ ] PDF出力で印刷設定が「高さに合わせる」になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)