### PR TITLE
fix: 居療管の病状・経過列を部分一致で特定（「奇数月」接頭辞に対応）

### DIFF
--- a/projects/home-care-guidance-document/gas/data-loaders.gs
+++ b/projects/home-care-guidance-document/gas/data-loaders.gs
@@ -35,6 +35,12 @@ function buildPatientMap(rows) {
   const header = rows[0];
   const normalizedHeader = header.map(value => normalizeCircledNumbers(value || ''));
   const index = name => normalizedHeader.indexOf(normalizeCircledNumbers(name));
+  // 訪問コメント列は「奇数月」「偶数月」などの接頭辞が付くことがあるため、部分一致で特定する。
+  // 接頭辞の有無・種類に依存しないため、月の奇偶でヘッダ名が変わっても列を取りこぼさない。
+  const indexByContains = keyword => {
+    const target = normalizeCircledNumbers(keyword);
+    return normalizedHeader.findIndex(value => value.includes(target));
+  };
 
   const col = {
     patientId: index('患者ID'),
@@ -50,10 +56,10 @@ function buildPatientMap(rows) {
     dementia: index('認知度'),
     careLevel: index('介護認定'),
     caution: index('日常生活や介護サービスを利用する上での留意点'),
-    visit1Stable: index('定期訪問①（著変なし）'),
-    visit1Change: index('定期訪問①（変更あり）'),
-    visit2Stable: index('定期訪問②（著変なし）'),
-    visit2Change: index('定期訪問②（変更あり）')
+    visit1Stable: indexByContains('定期訪問①（著変なし）'),
+    visit1Change: indexByContains('定期訪問①（変更あり）'),
+    visit2Stable: indexByContains('定期訪問②（著変なし）'),
+    visit2Change: indexByContains('定期訪問②（変更あり）')
   };
 
   rows.slice(1).forEach(row => {


### PR DESCRIPTION
## 概要
患者CSVの訪問コメント列名に「奇数月」接頭辞が追加されたことで、完全一致による列特定が失敗し、居宅療養管理指導書のC22（病状・経過）が空のまま出力される不具合を修正。

## 原因
`data-loaders.gs` の `buildPatientMap` はヘッダ列名の**完全一致**で訪問4列を特定していた。5月分CSVで列名が `定期訪問①（著変なし）` → `奇数月定期訪問①（著変なし）` 等に変更され、`index()` が -1 を返し病状・経過が空文字になっていた（例外は出ないため気付きにくい）。

## 変更内容
- `data-loaders.gs`: 部分一致用 `indexByContains` を追加し、訪問4列（visit1/2 × 著変なし/変更あり）の特定に使用。接頭辞（奇数月/偶数月/なし）に依存せず列を拾える。

## フォルダ構造チェック

| フォルダ | .md数 | .csv数 | 判定 | 対応 |
|---|---|---|---|---|
| projects/home-care-guidance-document/gas/ | 0 | 0 | OK | — |
| projects/home-care-guidance-document/ | 1 | 2 | OK | — |

## 備考
- 1CSVに「奇数月」「偶数月」両方（計8列）が同時に含まれる運用になった場合は、先頭一致のため奇偶の区別ができない。その場合は別途ロジックが必要（現状は月ごとに片方のみのため問題なし）。