### PR TITLE
update: .gitignore に .serena/ を追加（Serena MCP の除外）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ tmp/
 
 # 納品物（ローカルにのみ保持・git管理しない）
 deliverables/spec-docs/
+
+# Serena (MCP code-intelligence cache/config)
+.serena/


### PR DESCRIPTION
## 概要
Serena MCP が各リポジトリ直下に生成する `.serena/`（設定＋キャッシュ）を git 管理から除外する。

## 変更内容
- `.gitignore`: `.serena/` を追加（kaiser-diagrams は新規作成、他は末尾追記）

## フォルダ構造チェック
| 対象 | .md数 | .csv数 | 判定 | 対応 |
|---|---|---|---|---|
| 各リポジトリ直下（変更箇所＝.gitignore） | ≤3 | 0 | OK | 設定変更のみ。.md/.csv の追加なし＝肥大化リスクなし |